### PR TITLE
Fix style generation on older WebKit engines.

### DIFF
--- a/app/scripts/browser.js
+++ b/app/scripts/browser.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var _ = require('underscore');
+
+// Utilities for cross-browser compatibility.
+var Browser = {};
+
+// Map of CSS properties to property names used by the DOM in this browser.
+var normalizedProperties = {
+  'transform': _.find(['transform', 'WebkitTransform'], function (property) {
+    return document.documentElement.style[property] !== undefined;
+  }) || 'transform'
+};
+
+// Convert CSS properties and values to equivalent properties and values for
+// this browser.
+Browser.normalizeStyles = function (styles) {
+  var normalized = {};
+  _.forEach(_.keys(styles), function (property) {
+    normalized[normalizedProperties[property]] = styles[property];
+  })
+  return normalized;
+};
+
+module.exports = Browser;

--- a/app/scripts/grid.js
+++ b/app/scripts/grid.js
@@ -3,6 +3,7 @@
 var m = require('mithril');
 var _ = require('underscore');
 var classNames = require('classnames');
+var Browser = require('./browser');
 
 function Grid(args) {
   this.columnCount = args.columnCount;
@@ -140,12 +141,12 @@ Grid.Component.view = function (ctrl, game) {
            {'transition-x': ctrl.transitionPendingChipX},
            {'transition-y': ctrl.transitionPendingChipY}
         ),
-        style: {
+        style: Browser.normalizeStyles({
           transform: ctrl.getTranslate({
             x: ctrl.pendingChipX,
             y: ctrl.pendingChipY
           })
-        }
+        })
       }) : null,
     // Bottom grid of slots (indicating space chips can occupy)
     m('div#chip-slots', _.times(grid.columnCount, function (c) {


### PR DESCRIPTION
The chip would not slide around on very old iOS versions, and, apparently and perhaps more significantly, on the last leg of Android browsers: http://caniuse.com/#feat=transforms2d