### PR TITLE
feat: add SQLite game history and replay functionality

### DIFF
--- a/scripts/components/history.jsx
+++ b/scripts/components/history.jsx
@@ -1,0 +1,124 @@
+import m from 'mithril';
+
+function formatDate(ts) {
+  if (!ts) return '—';
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
+
+function duration(startedAt, endedAt) {
+  if (!startedAt || !endedAt) return '—';
+  const secs = Math.round((endedAt - startedAt) / 1000);
+  if (secs < 60) return `${secs}s`;
+  return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+}
+
+class HistoryComponent {
+  oninit() {
+    this.games = [];
+    this.loading = true;
+    this.error = null;
+    this.loadGames();
+  }
+
+  loadGames() {
+    m.request({ method: 'GET', url: '/api/games' })
+      .then((games) => {
+        this.games = games;
+        this.loading = false;
+      })
+      .catch(() => {
+        this.error = 'Failed to load history.';
+        this.loading = false;
+      });
+  }
+
+  view() {
+    return (
+      <div id="history">
+        <h1>Connect Four</h1>
+        <h2>Game History</h2>
+        {this.loading ? (
+          <p className="history-message">Loading...</p>
+        ) : this.error ? (
+          <p className="history-message history-error">{this.error}</p>
+        ) : this.games.length === 0 ? (
+          <p className="history-message">No games recorded yet.</p>
+        ) : (
+          <table className="history-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Players</th>
+                <th>Winner</th>
+                <th>Moves</th>
+                <th>Duration</th>
+                <th>Result</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {this.games.map((g) => {
+                const isDraw = g.status === 'completed' && !g.winner_color;
+                const isAbandoned = g.status === 'abandoned';
+                const isInProgress = g.status === 'in_progress';
+                return (
+                  <tr key={g.id} className={isAbandoned ? 'abandoned' : ''}>
+                    <td className="history-date">{formatDate(g.started_at)}</td>
+                    <td className="history-players">
+                      <span className={`history-player ${g.player1_color}`}>
+                        {g.player1_name}
+                      </span>
+                      <span className="history-vs">vs</span>
+                      <span className={`history-player ${g.player2_color || ''}`}>
+                        {g.player2_name || '—'}
+                      </span>
+                    </td>
+                    <td className={`history-winner ${g.winner_color || ''}`}>
+                      {g.winner_color === g.player1_color
+                        ? g.player1_name
+                        : g.winner_color === g.player2_color
+                          ? g.player2_name
+                          : '—'}
+                    </td>
+                    <td className="history-moves">{g.total_moves}</td>
+                    <td className="history-duration">{duration(g.started_at, g.ended_at)}</td>
+                    <td className="history-status">
+                      {isInProgress ? (
+                        <span className="badge in-progress">Live</span>
+                      ) : isDraw ? (
+                        <span className="badge draw">Draw</span>
+                      ) : isAbandoned ? (
+                        <span className="badge abandoned">Abandoned</span>
+                      ) : (
+                        <span className="badge completed">Completed</span>
+                      )}
+                    </td>
+                    <td className="history-replay">
+                      {g.total_moves > 0 ? (
+                        <a href={`/history/${g.id}`}>Replay</a>
+                      ) : null}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+        <div className="history-footer">
+          <button onclick={() => this.loadGames()} disabled={this.loading}>
+            Refresh
+          </button>
+          <a href="/rooms">Browse Rooms</a>
+          <a href="/">Home</a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default HistoryComponent;

--- a/scripts/components/replay.jsx
+++ b/scripts/components/replay.jsx
@@ -1,0 +1,326 @@
+import clsx from 'clsx';
+import m from 'mithril';
+
+const COLS = 7;
+const ROWS = 6;
+
+// Directions to check for a 4-in-a-row: horizontal, vertical, two diagonals
+const DIRECTIONS = [
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [1, -1]
+];
+
+// Build a columns[c][r] grid state from the first `count` moves in the moves array
+function buildColumns(moves, count) {
+  const columns = Array.from({ length: COLS }, () => []);
+  for (let i = 0; i < count; i++) {
+    const { column_index, player_color } = moves[i];
+    columns[column_index].push({ color: player_color });
+  }
+  return columns;
+}
+
+// Return a Set of "c,r" keys for chips that form a winning connection
+function findWinners(columns) {
+  const get = (c, r) => columns[c]?.[r];
+  const winners = new Set();
+  for (let c = 0; c < COLS; c++) {
+    for (let r = 0; r < ROWS; r++) {
+      const chip = get(c, r);
+      if (!chip) continue;
+      for (const [dc, dr] of DIRECTIONS) {
+        const seq = [];
+        for (let k = 0; k < 4; k++) {
+          if (get(c + dc * k, r + dr * k)?.color === chip.color) {
+            seq.push(`${c + dc * k},${r + dr * k}`);
+          }
+        }
+        if (seq.length === 4) seq.forEach((key) => winners.add(key));
+      }
+    }
+  }
+  return winners;
+}
+
+class ReplayComponent {
+  oninit({ attrs }) {
+    this.gameId = attrs.gameId;
+    this.game = null;
+    this.moves = [];
+    this.stepIndex = 0;
+    this.playing = false;
+    this.playSpeed = 700;
+    this.playTimer = null;
+    this.loading = true;
+    this.error = null;
+    this.loadGame();
+  }
+
+  onremove() {
+    this.pause();
+  }
+
+  loadGame() {
+    m.request({ method: 'GET', url: `/api/games/${this.gameId}` })
+      .then((data) => {
+        this.game = data;
+        this.moves = data.moves || [];
+        this.loading = false;
+      })
+      .catch(() => {
+        this.error = 'Failed to load game.';
+        this.loading = false;
+      });
+  }
+
+  get atStart() {
+    return this.stepIndex === 0;
+  }
+
+  get atEnd() {
+    return this.stepIndex === this.moves.length;
+  }
+
+  seek(index) {
+    this.stepIndex = Math.max(0, Math.min(index, this.moves.length));
+    if (this.atEnd) this.pause();
+  }
+
+  stepBack() {
+    this.seek(this.stepIndex - 1);
+  }
+
+  stepForward() {
+    this.seek(this.stepIndex + 1);
+  }
+
+  play() {
+    if (this.atEnd) this.seek(0);
+    this.playing = true;
+    this.scheduleNextStep();
+    m.redraw();
+  }
+
+  pause() {
+    this.playing = false;
+    clearTimeout(this.playTimer);
+    this.playTimer = null;
+  }
+
+  togglePlay() {
+    if (this.playing) {
+      this.pause();
+    } else {
+      this.play();
+    }
+  }
+
+  scheduleNextStep() {
+    this.playTimer = setTimeout(() => {
+      this.stepIndex++;
+      if (this.atEnd) {
+        this.pause();
+      } else {
+        this.scheduleNextStep();
+      }
+      m.redraw();
+    }, this.playSpeed);
+  }
+
+  setSpeed(ms) {
+    this.playSpeed = ms;
+    if (this.playing) {
+      clearTimeout(this.playTimer);
+      this.scheduleNextStep();
+    }
+  }
+
+  view() {
+    if (this.loading) {
+      return (
+        <div id="replay">
+          <h1>Connect Four</h1>
+          <p className="replay-message">Loading...</p>
+        </div>
+      );
+    }
+    if (this.error) {
+      return (
+        <div id="replay">
+          <h1>Connect Four</h1>
+          <p className="replay-message replay-error">{this.error}</p>
+          <div className="replay-footer">
+            <a href="/history">← History</a>
+          </div>
+        </div>
+      );
+    }
+
+    const columns = buildColumns(this.moves, this.stepIndex);
+    const isGameOver = this.atEnd && this.game.status === 'completed';
+    const winners = isGameOver && this.game.winner_color ? findWinners(columns) : new Set();
+    const currentMove = this.stepIndex > 0 ? this.moves[this.stepIndex - 1] : null;
+
+    const nameOf = (color) =>
+      color === this.game.player1_color ? this.game.player1_name : this.game.player2_name;
+
+    let statusText;
+    if (this.atEnd) {
+      if (this.game.winner_color) {
+        statusText = `${nameOf(this.game.winner_color)} wins!`;
+      } else if (this.game.status === 'completed') {
+        statusText = "It's a draw!";
+      } else {
+        statusText = 'Game abandoned';
+      }
+    } else if (this.stepIndex === 0) {
+      statusText = 'Press play or use the controls to step through the game';
+    } else {
+      statusText = `Move ${this.stepIndex} — ${nameOf(currentMove.player_color)} placed in column ${currentMove.column_index + 1}`;
+    }
+
+    return (
+      <div id="replay">
+        <h1>Connect Four</h1>
+        <h2>Replay</h2>
+
+        <div className="replay-players">
+          <span className={`replay-player ${this.game.player1_color}`}>
+            {this.game.player1_name}
+          </span>
+          <span className="replay-vs">vs</span>
+          <span className={`replay-player ${this.game.player2_color || ''}`}>
+            {this.game.player2_name || '—'}
+          </span>
+        </div>
+
+        <p className="replay-status">{statusText}</p>
+
+        {/* Board */}
+        <div
+          id="replay-grid-columns"
+          className={clsx({ 'game-over': isGameOver, 'has-winner': !!this.game.winner_color })}
+        >
+          {Array.from({ length: COLS }, (_, c) => (
+            <div key={c} className="grid-column">
+              {Array.from({ length: ROWS }, (_, r) => {
+                const chip = columns[c][r];
+                const isWinner = winners.has(`${c},${r}`);
+                const isLastPlaced =
+                  currentMove &&
+                  currentMove.column_index === c &&
+                  currentMove.row_index === r;
+                return chip ? (
+                  <div
+                    key={r}
+                    className={clsx('chip', chip.color, {
+                      winning: isWinner,
+                      'last-placed': isLastPlaced
+                    })}
+                  >
+                    <div className="chip-inner"></div>
+                  </div>
+                ) : (
+                  <div key={r} className="empty-chip-slot">
+                    <div className="empty-chip-slot-inner"></div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Scrubber */}
+        <div className="replay-scrubber">
+          <span className="replay-step-count">
+            {this.stepIndex} / {this.moves.length}
+          </span>
+          <input
+            type="range"
+            min="0"
+            max={this.moves.length}
+            value={this.stepIndex}
+            oninput={(e) => {
+              this.pause();
+              this.seek(parseInt(e.target.value));
+            }}
+          />
+        </div>
+
+        {/* Transport controls */}
+        <div className="replay-controls">
+          <button
+            onclick={() => {
+              this.pause();
+              this.seek(0);
+            }}
+            disabled={this.atStart}
+            title="Reset"
+          >
+            ⏮
+          </button>
+          <button
+            onclick={() => {
+              this.pause();
+              this.stepBack();
+            }}
+            disabled={this.atStart}
+            title="Step back"
+          >
+            ⏴
+          </button>
+          <button className="play-pause" onclick={() => this.togglePlay()} title={this.playing ? 'Pause' : 'Play'}>
+            {this.playing ? '⏸' : '▶'}
+          </button>
+          <button
+            onclick={() => {
+              this.pause();
+              this.stepForward();
+            }}
+            disabled={this.atEnd}
+            title="Step forward"
+          >
+            ⏵
+          </button>
+          <button
+            onclick={() => {
+              this.pause();
+              this.seek(this.moves.length);
+            }}
+            disabled={this.atEnd}
+            title="Jump to end"
+          >
+            ⏭
+          </button>
+        </div>
+
+        {/* Speed selector */}
+        <div className="replay-speed">
+          <span className="replay-speed-label">Speed:</span>
+          {[
+            ['Slow', 1200],
+            ['Normal', 700],
+            ['Fast', 300]
+          ].map(([label, ms]) => (
+            <button
+              key={label}
+              className={clsx({ active: this.playSpeed === ms })}
+              onclick={() => this.setSpeed(ms)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="replay-footer">
+          <a href="/history">← History</a>
+          <a href="/">Home</a>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ReplayComponent;

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,41 @@
+import { DatabaseSync } from 'node:sqlite';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataDir = path.join(__dirname, '..', 'data');
+fs.mkdirSync(dataDir, { recursive: true });
+
+const db = new DatabaseSync(path.join(dataDir, 'games.db'));
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS games (
+    id TEXT PRIMARY KEY,
+    room_code TEXT NOT NULL,
+    player1_id TEXT NOT NULL,
+    player1_name TEXT NOT NULL,
+    player1_color TEXT NOT NULL,
+    player2_id TEXT,
+    player2_name TEXT,
+    player2_color TEXT,
+    winner_id TEXT,
+    winner_color TEXT,
+    status TEXT NOT NULL DEFAULT 'in_progress',
+    started_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    total_moves INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE IF NOT EXISTS game_moves (
+    id TEXT PRIMARY KEY,
+    game_id TEXT NOT NULL,
+    player_id TEXT NOT NULL,
+    player_color TEXT NOT NULL,
+    column_index INTEGER NOT NULL,
+    row_index INTEGER NOT NULL,
+    move_number INTEGER NOT NULL,
+    placed_at INTEGER NOT NULL
+  );
+`);
+
+export default db;

--- a/server/game.js
+++ b/server/game.js
@@ -22,6 +22,8 @@ class Game {
     this.pendingChipColumn = pendingChipColumn;
     this.winner = winner;
     this.pendingNewGame = pendingNewGame;
+    this.dbId = null;
+    this.moveCount = 0;
   }
 
   startGame() {

--- a/styles/_history.scss
+++ b/styles/_history.scss
@@ -1,0 +1,168 @@
+// Game History page
+
+#history {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--page-spacing-top) var(--page-spacing-x) 40px;
+  text-align: center;
+
+  h2 {
+    font-weight: 400;
+    font-size: 20px;
+    margin: 0 0 20px;
+  }
+}
+
+.history-message {
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.history-error {
+  color: var(--button-warn-background-color);
+  opacity: 1;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  text-align: left;
+  margin-bottom: 20px;
+
+  th {
+    font-weight: 600;
+    padding: 6px 10px;
+    border-bottom: 2px solid var(--empty-chip-slot-border-color);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--empty-chip-slot-border-color);
+    vertical-align: middle;
+  }
+
+  tr.abandoned td {
+    opacity: 0.5;
+  }
+}
+
+.history-date {
+  white-space: nowrap;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.history-players {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.history-player {
+  &.red {
+    color: var(--player-color-red);
+  }
+  &.blue {
+    color: var(--player-color-blue);
+  }
+}
+
+.history-vs {
+  font-size: 11px;
+  opacity: 0.45;
+}
+
+.history-winner {
+  font-weight: 600;
+  &.red {
+    color: var(--player-color-red);
+  }
+  &.blue {
+    color: var(--player-color-blue);
+  }
+}
+
+.history-moves,
+.history-duration {
+  text-align: center;
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.history-status {
+  text-align: center;
+}
+
+.history-replay {
+  text-align: center;
+  a {
+    font-size: 12px;
+    white-space: nowrap;
+  }
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+
+  &.completed {
+    background-color: hsl(100, 60%, 88%);
+    color: hsl(100, 60%, 25%);
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(100, 40%, 20%);
+      color: hsl(100, 60%, 70%);
+    }
+  }
+  &.draw {
+    background-color: hsl(220, 60%, 88%);
+    color: hsl(220, 60%, 30%);
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(220, 40%, 22%);
+      color: hsl(220, 70%, 70%);
+    }
+  }
+  &.in-progress {
+    background-color: hsl(28, 100%, 88%);
+    color: hsl(28, 80%, 30%);
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(28, 60%, 22%);
+      color: hsl(28, 90%, 65%);
+    }
+  }
+  &.abandoned {
+    background-color: hsl(0, 0%, 88%);
+    color: hsl(0, 0%, 35%);
+    @media (prefers-color-scheme: dark) {
+      background-color: hsl(0, 0%, 22%);
+      color: hsl(0, 0%, 60%);
+    }
+  }
+}
+
+.history-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  font-size: 14px;
+
+  button {
+    border: solid 1px hsla(0, 0%, 0%, 0.25);
+    border-radius: 3px;
+    padding: 4px 10px;
+    background-color: var(--button-background-color);
+    font-family: var(--sans-serif);
+    color: var(--button-color);
+    cursor: pointer;
+
+    &:disabled {
+      --button-background-color: var(--button-disabled-background-color);
+    }
+  }
+}

--- a/styles/_replay.scss
+++ b/styles/_replay.scss
@@ -1,0 +1,198 @@
+// Game replay page
+
+#replay {
+  max-width: 520px;
+  margin: 0 auto;
+  padding: var(--page-spacing-top) var(--page-spacing-x) 40px;
+  text-align: center;
+
+  h2 {
+    font-weight: 400;
+    font-size: 20px;
+    margin: 0 0 12px;
+  }
+}
+
+.replay-players {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 15px;
+  margin-bottom: 8px;
+}
+
+.replay-player {
+  font-weight: 600;
+  &.red {
+    color: var(--player-color-red);
+  }
+  &.blue {
+    color: var(--player-color-blue);
+  }
+  &.black {
+    color: var(--player-color-black);
+  }
+}
+
+.replay-vs {
+  font-size: 11px;
+  opacity: 0.45;
+}
+
+.replay-status {
+  font-size: 13px;
+  min-height: 1.5em;
+  margin: 0 0 16px;
+  opacity: 0.75;
+}
+
+.replay-message {
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.replay-error {
+  color: var(--button-warn-background-color);
+  opacity: 1;
+}
+
+// Board
+
+#replay-grid-columns {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+
+  // Fade non-winning chips when a winner is shown
+  &.game-over.has-winner .chip:not(.winning) {
+    .chip-inner {
+      opacity: 0.3;
+    }
+  }
+
+  .chip.last-placed .chip-inner {
+    box-shadow: 0 0 0 3px white, 0 0 0 5px hsla(0, 0%, 0%, 0.25);
+  }
+}
+
+// Scrubber
+
+.replay-scrubber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 12px;
+
+  input[type='range'] {
+    width: 220px;
+    cursor: pointer;
+    accent-color: var(--button-background-color);
+  }
+}
+
+.replay-step-count {
+  font-size: 12px;
+  opacity: 0.6;
+  min-width: 46px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+// Transport controls
+
+.replay-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 10px;
+
+  button {
+    background: none;
+    border: solid 1px hsla(0, 0%, 0%, 0.2);
+    border-radius: 4px;
+    padding: 5px 10px;
+    font-size: 16px;
+    cursor: pointer;
+    color: var(--app-text-color);
+    line-height: 1;
+    transition: background-color 0.1s;
+
+    &:hover:not(:disabled) {
+      background-color: hsla(0, 0%, 0%, 0.06);
+    }
+    &:disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+    &:focus {
+      outline: none;
+    }
+    @media (prefers-color-scheme: dark) {
+      border-color: hsla(0, 0%, 100%, 0.2);
+      &:hover:not(:disabled) {
+        background-color: hsla(0, 0%, 100%, 0.08);
+      }
+    }
+  }
+
+  .play-pause {
+    padding: 5px 14px;
+    font-size: 18px;
+  }
+}
+
+// Speed selector
+
+.replay-speed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.replay-speed-label {
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+.replay-speed button {
+  background: none;
+  border: solid 1px hsla(0, 0%, 0%, 0.2);
+  border-radius: 10px;
+  padding: 2px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--app-text-color);
+  transition: background-color 0.1s;
+
+  &:hover {
+    background-color: hsla(0, 0%, 0%, 0.06);
+  }
+  &.active {
+    background-color: var(--button-background-color);
+    color: var(--button-color);
+    border-color: transparent;
+  }
+  &:focus {
+    outline: none;
+  }
+  @media (prefers-color-scheme: dark) {
+    border-color: hsla(0, 0%, 100%, 0.2);
+    &:hover {
+      background-color: hsla(0, 0%, 100%, 0.08);
+    }
+  }
+}
+
+// Footer
+
+.replay-footer {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
This PR introduces server-side persistence for game results and the ability for users to review past games.

## Key Changes
- **Database:** Implemented `server/db.js` using Node's built-in `node:sqlite` module.
- **API:** Added endpoints to fetch game history and individual move data.
- **UI:** 
  - Added `History` component to list recent games.
  - Added `Replay` component to visualize past matches move-by-move.
- **Styles:** Added SCSS for history and replay views.